### PR TITLE
Fixes a number of memory issues reported by AddressSanitizer.

### DIFF
--- a/toml_parse.rl
+++ b/toml_parse.rl
@@ -24,6 +24,7 @@ struct toml_stack_item {
 	struct toml_stack_item* context = CONTEXT(&context_stack);	\
 	list_del(&context->list);									\
 	x = context->node;											\
+    free(context);                                              \
 } while (0)
 
 static size_t
@@ -301,6 +302,7 @@ add_node_to_tree(struct list_head* context_stack, struct toml_node* node, char* 
 
 		context->list_type = TOML_LIST;
 		item->node.type = TOML_LIST;
+        item->node.name = NULL;
 		if (name)
 		{
 			item->node.name = name;
@@ -768,6 +770,10 @@ toml_parse(struct toml_node* toml_root, char* buf, int buflen)
 	pe = buf + buflen + 1;
 
 	%% write exec;
+
+    while ((root = CONTEXT(&context_stack))) {
+        POP_CONTEXT(toml_root);
+    }
 
 	if (malloc_error) {
 		fprintf(stderr, "malloc failed, line %d\n", cur_line);


### PR DESCRIPTION
This PR fixes a number of memory issues reported by *AddressSanitizer*.

### Memory Leaks
*ASan* detects lots of leaks. They all look similar to the below...

    Direct leak of 128 byte(s) in 4 object(s) allocated from:
        #0 0x2b58317fb6f0 in __interceptor_malloc ../../../../gcc-8.1.0/libsanitizer/asan/asan_malloc_linux.cc:86
        #1 0x2b58326eb506 in make_stack_item /vagrant/toml_parse.rl:731
        #2 0x2b58326ed9b1 in toml_parse /vagrant/toml_parse.rl:322
        #3 0x401beb in main /vagrant/main.c:120
        #4 0x32e301d9f3 in __libc_start_main (/lib64/libc.so.6+0x32e301d9f3)

    Indirect leak of 64 byte(s) in 2 object(s) allocated from:
        #0 0x2b58317fb6f0 in __interceptor_malloc ../../../../gcc-8.1.0/libsanitizer/asan/asan_malloc_linux.cc:86
        #1 0x2b58326eb506 in make_stack_item /vagrant/toml_parse.rl:731
        #2 0x2b58326ee2f2 in toml_parse /vagrant/toml_parse.rl:413
        #3 0x401beb in main /vagrant/main.c:120
        #4 0x32e301d9f3 in __libc_start_main (/lib64/libc.so.6+0x32e301d9f3)

The fixes for these are...

1. Add `free(context)` to the `POP_CONTEXT(x)` macro. (`toml_parse.rl`)
2. After the `%%write_exec` section, loop over the remaining items in the context stack, calling `POP_CONTEXT(...)` on each. (`toml_parse.rl`)

### Invalid Memory Access
The `examples/example.toml` file fails *ASan*, giving the following error...

    AddressSanitizer:DEADLYSIGNAL
    =================================================================
    ==6764==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x2b6d54e31272 bp 0x7fffc51990d0 sp 0x7fffc5198808 T0)
    ==6764==The signal is caused by a READ memory access.
    ==6764==Hint: address points to the zero page.
        #0 0x2b6d54e31271 in __sanitizer::internal_strlen(char const*) ../../../../gcc-8.1.0/libsanitizer/sanitizer_common/sanitizer_libc.cc:171
        #1 0x2b6d54d7b22c in printf_common ../../../../gcc-8.1.0/libsanitizer/sanitizer_common/sanitizer_common_interceptors_format.inc:544
        #2 0x2b6d54d7bb52 in __interceptor_vfprintf ../../../../gcc-8.1.0/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1505
        #3 0x2b6d54d7bc16 in __interceptor_fprintf ../../../../gcc-8.1.0/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1550
        #4 0x2b6d55d0353c in _toml_dump /vagrant/toml.c:108
        #5 0x2b6d55d035f3 in _toml_dump /vagrant/toml.c:111
        #6 0x2b6d55d03416 in _toml_dump /vagrant/toml.c:97
        #7 0x2b6d55d03270 in _toml_dump /vagrant/toml.c:81
        #8 0x2b6d55d03d34 in toml_dump /vagrant/toml.c:208
        #9 0x401dc3 in main /vagrant/main.c:141
        #10 0x32e301d9f3 in __libc_start_main (/lib64/libc.so.6+0x32e301d9f3)
        #11 0x401158  (/vagrant/build/main+0x401158)

It appears to be a problem with lists. Ensuring that, if there is no `name` present, setting `item->node.name = NULL` in the `start_list` action appears to fix this. (`toml_parse.rl`)

**NOTE**: I've only tested these fixes with the provided example `.toml` files in the project. However, it looks as though these fixes may go some way to addressing issues #18, ~~#19~~, #20, #22, #23, and #24.
